### PR TITLE
Fix reports of food court demise link

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <h1>Tuesday, Dec 10 at noon</h1>
     <h3>International Food Court</h3>
     <p>19th and Eye St, NW, in the basement.</p>
-    <p>Note that there are <a href=""https://www.popville.com/2019/12/dc-international-square-food-court-closing/">reports</a> that International Square is closing! So come celebrate the great times and brainstorm future newsnerd lunch loactions</p>
+    <p>Note that there are <a href="https://www.popville.com/2019/12/dc-international-square-food-court-closing/">reports</a> that International Square is closing! So come celebrate the great times and brainstorm future newsnerd lunch loactions</p>
 
     <hr />
     <h5><strong>Previous lunch</strong>: in October at International Food Court </h5>


### PR DESCRIPTION
The "reports" link has an errant quote mark. Clicking on it takes you back to whenisdcnewsnerdslunch.com. This PR removes the errant mark.